### PR TITLE
Farabi/fix-error-handling

### DIFF
--- a/src/javascript/app/pages/trade/common.js
+++ b/src/javascript/app/pages/trade/common.js
@@ -175,6 +175,7 @@ const commonTrading = (() => {
         $('.purchase_button').text(localize('Purchase'));
         dataManager.setPurchase({
             show_purchase_results: false,
+            error                : null,
         });
     };
 

--- a/src/javascript/app/pages/trade/purchase.js
+++ b/src/javascript/app/pages/trade/purchase.js
@@ -88,25 +88,19 @@ const Purchase = (() => {
                 // Show insufficient balance error without top-up popup
                 contracts_list.style.display = 'none';
                 container.style.display = 'block';
-                dataManager.setPurchase({
-                    show_purchase_results: true,
-                });
-
                 message_container.hide();
                 confirmation_error.setVisibility(1);
                 CommonFunctions.elementInnerHtml(confirmation_error, mapErrorMessage(error));
-                
+
                 dataManager.setPurchase({
-                    error: { ...error },
+                    show_purchase_results: true,
+                    error                : { ...error },
                 });
             } else {
                 contracts_list.style.display = 'none';
                 container.style.display = 'block';
-                dataManager.setPurchase({
-                    show_purchase_results: true,
-                });
-
                 message_container.hide();
+
                 if (/AuthorizationRequired/.test(error.code)) {
                     authorization_error.setVisibility(1);
                     const authorization_error_btn_login = CommonFunctions.getElementById('authorization_error_btn_login');
@@ -117,7 +111,8 @@ const Purchase = (() => {
                     const signup_url = getBrandSignupUrl();
 
                     dataManager.setPurchase({
-                        error: {
+                        show_purchase_results: true,
+                        error                : {
                             ...error,
                             signup_url,
                             title    : localize('Ready to trade?'),
@@ -126,10 +121,17 @@ const Purchase = (() => {
                     });
 
                 } else {
+                    const basic_message = mapErrorMessage(error);
+                    dataManager.setPurchase({
+                        show_purchase_results: true,
+                        error                : { ...error, message: basic_message },
+                    });
+                    confirmation_error.setVisibility(1);
+                    CommonFunctions.elementInnerHtml(confirmation_error, basic_message);
+
                     BinarySocket.wait('get_account_status').then(response => {
-                        confirmation_error.setVisibility(1);
-                        let message = mapErrorMessage(error);
-                      
+                        let message = basic_message;
+
                         if (/NoMFProfessionalClient/.test(error.code)) {
                             const account_status = getPropertyValue(response, ['get_account_status', 'status']) || [];
                             const has_professional_requested = account_status.includes('professional_requested');
@@ -167,11 +169,12 @@ const Purchase = (() => {
                             }
                         }
 
-                        dataManager.setPurchase({
-                            error: { ...error,message },
-                        });
-
-                        CommonFunctions.elementInnerHtml(confirmation_error, message);
+                        if (message !== basic_message) {
+                            dataManager.setPurchase({
+                                error: { ...error, message },
+                            });
+                            CommonFunctions.elementInnerHtml(confirmation_error, message);
+                        }
                     });
                 }
             }


### PR DESCRIPTION
This pull request updates the way purchase errors are handled and displayed in the trading application. The main focus is on ensuring that error information is consistently passed and shown to the user, including improved messaging for specific error cases.

**Error Handling and Messaging Improvements:**

* When a purchase error occurs, the `error` object is now always included in the `dataManager.setPurchase` call, ensuring error details are available for downstream components. 
* For errors requiring user authorization, the `signup_url` is now included in the error object, providing users with a direct link to sign up. (`src/javascript/app/pages/trade/purchase.js`)
* For other errors, the mapped error message is now attached to the error object and displayed to the user, ensuring clarity in the UI. (`src/javascript/app/pages/trade/purchase.js`)
* When additional account status information changes the error message (e.g., for professional client status), the error object and UI are updated accordingly. (`src/javascript/app/pages/trade/purchase.js`)

**General State Management:**

* The `error` property is now initialized to `null` when resetting the purchase state, ensuring no stale error data persists between purchases. (`src/javascript/app/pages/trade/common.js`)