### PR TITLE
Farabi/grwt-9279/fix-auto-balance-update

### DIFF
--- a/src/javascript/app/base/socket_general.js
+++ b/src/javascript/app/base/socket_general.js
@@ -13,6 +13,9 @@ const getPropertyValue       = require('../../_common/utility').getPropertyValue
 const isLoginPages           = require('../../_common/utility').isLoginPages;
 
 const BinarySocketGeneral = (() => {
+    // Runs balance setup only once per page load.
+    let has_initialized_balance = false;
+
     const onOpen = (is_ready) => {
         Header.hideNotification();
         if (is_ready) {
@@ -37,19 +40,20 @@ const BinarySocketGeneral = (() => {
                     }
                     Client.sendLogoutRequest(is_active_tab);
                 } else if (!isLoginPages() && !/balance/.test(State.get('skip_response'))) {
-                    // Check if this is the first balance (auth confirmation)
-                    const isFirstBalance = !Client.get('loginid');
-
-                    if (isFirstBalance) {
-                        // First balance response - set up subscriptions
+                    // Sync the active account so balance updates aren't dropped.
+                    if (Client.get('loginid') !== getPropertyValue(response, ['balance', 'loginid'])) {
                         Client.responseBalance(response);
+                    }
+
+                    // Run setup once.
+                    if (!has_initialized_balance) {
+                        has_initialized_balance = true;
                         SubscriptionManager.subscribe('transaction', { transaction: 1, subscribe: 1 }, () => false);
                         BinarySocket.sendBuffered();
                         LocalStore.remove('date_first_contact');
                         LocalStore.remove('signup_device');
                     }
 
-                    // Always update balance display
                     updateBalance(response);
                 }
                 break;


### PR DESCRIPTION
This pull request updates the balance initialization logic in `socket_general.js` to ensure that balance setup and related subscriptions are only run once per page load, regardless of account switching. The changes also improve how balance updates are handled when switching accounts.

**Balance initialization improvements:**

* Introduced a `has_initialized_balance` flag to ensure balance setup (such as subscribing to transactions and clearing local storage) is only performed once per page load, rather than on every balance response. 

**Account switching and balance updates:**

* Updated the logic so that when the active account changes, the balance is synchronized by checking if the `loginid` from the response matches the current client. If not, the balance is updated accordingly.