### PR TITLE
Farabi/webrel-6520/entry-spot-missing-in-contract-details

### DIFF
--- a/src/javascript/app/pages/user/view_popup/view_popup.js
+++ b/src/javascript/app/pages/user/view_popup/view_popup.js
@@ -323,7 +323,7 @@ const ViewPopup = (() => {
                 cd_info_msg  : localize('Contract has not started yet'),
             });
         } else {
-            if (contract.entry_spot > 0) {
+            if (parseFloat(String(contract.entry_spot).replace(/,/g, '')) > 0) {
                 // only show entry spot if available and contract was not sold before start time
                 containerSetText('trade_details_entry_spot > span', is_sold_before_start ? '-' : contract.entry_spot);
                 dataManager.setPurchase({


### PR DESCRIPTION
This pull request updates the logic for displaying the entry spot in the contract details popup to ensure more robust handling of numeric values. The main change improves how the code checks whether an entry spot exists by parsing and validating the value as a number.

**Bug fix and code robustness:**

* Updated the condition to check if `contract.entry_spot` is greater than zero by parsing it as a float and removing any commas, ensuring the check works correctly even if the value is a string with formatting. (`src/javascript/app/pages/user/view_popup/view_popup.js`)